### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/pkg/tools/diagnostics.go
+++ b/pkg/tools/diagnostics.go
@@ -16,6 +16,8 @@ func (t *LSPTools) registerDiagnosticsTools(s *server.MCPServer) {
 func (t *LSPTools) registerCheckDiagnostics(s *server.MCPServer) {
 	diagnosticsTool := mcp.NewTool("check_diagnostics",
 		mcp.WithDescription("Get diagnostics for a file"),
+		mcp.WithTitleAnnotation("Check Diagnostics"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),

--- a/pkg/tools/insight.go
+++ b/pkg/tools/insight.go
@@ -17,6 +17,8 @@ func (t *LSPTools) registerInsightTools(s *server.MCPServer) {
 func (t *LSPTools) registerHover(s *server.MCPServer) {
 	hoverTool := mcp.NewTool("get_hover_info",
 		mcp.WithDescription("Get hover information for a symbol"),
+		mcp.WithTitleAnnotation("Get Hover Info"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),
@@ -74,6 +76,8 @@ func (t *LSPTools) registerHover(s *server.MCPServer) {
 func (t *LSPTools) registerCompletion(s *server.MCPServer) {
 	completionTool := mcp.NewTool("get_completion",
 		mcp.WithDescription("Get completion suggestions at a position"),
+		mcp.WithTitleAnnotation("Get Completion"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),

--- a/pkg/tools/navigation.go
+++ b/pkg/tools/navigation.go
@@ -17,6 +17,8 @@ func (t *LSPTools) registerNavigationTools(s *server.MCPServer) {
 func (t *LSPTools) registerGoToDefinition(s *server.MCPServer) {
 	definitionTool := mcp.NewTool("go_to_definition",
 		mcp.WithDescription("Navigate to the definition of a symbol"),
+		mcp.WithTitleAnnotation("Go To Definition"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),
@@ -72,6 +74,8 @@ func (t *LSPTools) registerGoToDefinition(s *server.MCPServer) {
 func (t *LSPTools) registerFindReferences(s *server.MCPServer) {
 	referencesTool := mcp.NewTool("find_references",
 		mcp.WithDescription("Find all references to a symbol"),
+		mcp.WithTitleAnnotation("Find References"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),

--- a/pkg/tools/refactor.go
+++ b/pkg/tools/refactor.go
@@ -18,6 +18,8 @@ func (t *LSPTools) registerRefactorTools(s *server.MCPServer) {
 func (t *LSPTools) registerFormatDocument(s *server.MCPServer) {
 	tool := mcp.NewTool("format_document",
 		mcp.WithDescription("Return formatting edits for a Go file"),
+		mcp.WithTitleAnnotation("Format Document"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file to format"),
@@ -63,6 +65,8 @@ func (t *LSPTools) registerFormatDocument(s *server.MCPServer) {
 func (t *LSPTools) registerRenameSymbol(s *server.MCPServer) {
 	tool := mcp.NewTool("rename_symbol",
 		mcp.WithDescription("Compute rename edits for a symbol"),
+		mcp.WithTitleAnnotation("Rename Symbol"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),
@@ -128,6 +132,8 @@ func (t *LSPTools) registerRenameSymbol(s *server.MCPServer) {
 func (t *LSPTools) registerCodeActionsTool(s *server.MCPServer) {
 	tool := mcp.NewTool("list_code_actions",
 		mcp.WithDescription("List available code actions for a given range"),
+		mcp.WithTitleAnnotation("List Code Actions"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("file_uri",
 			mcp.Required(),
 			mcp.Description("URI of the file"),

--- a/pkg/tools/testing.go
+++ b/pkg/tools/testing.go
@@ -18,6 +18,8 @@ func (t *LSPTools) registerTestingTools(s *server.MCPServer) {
 func (t *LSPTools) registerCoverageAnalysis(s *server.MCPServer) {
 	coverageTool := mcp.NewTool("analyze_coverage",
 		mcp.WithDescription("Analyze test coverage for Go code"),
+		mcp.WithTitleAnnotation("Analyze Coverage"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Path to the package or directory to analyze. Defaults to ./..."),
 		),
@@ -113,6 +115,8 @@ func (t *LSPTools) runCoverageByFunction(ctx context.Context, srv *server.MCPSer
 func (t *LSPTools) registerGoTest(s *server.MCPServer) {
 	runTool := mcp.NewTool("run_go_test",
 		mcp.WithDescription("Run go test for a package or pattern"),
+		mcp.WithTitleAnnotation("Run Go Test"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Package path or pattern. Defaults to ./..."),
 		),

--- a/pkg/tools/workspace.go
+++ b/pkg/tools/workspace.go
@@ -23,6 +23,8 @@ func (t *LSPTools) registerWorkspaceTools(s *server.MCPServer) {
 func (t *LSPTools) registerWorkspaceSymbols(s *server.MCPServer) {
 	tool := mcp.NewTool("search_workspace_symbols",
 		mcp.WithDescription("Search workspace symbols via LSP"),
+		mcp.WithTitleAnnotation("Search Workspace Symbols"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description("Search query"),
@@ -64,6 +66,8 @@ func (t *LSPTools) registerWorkspaceSymbols(s *server.MCPServer) {
 func (t *LSPTools) registerGoModTidy(s *server.MCPServer) {
 	tool := mcp.NewTool("run_go_mod_tidy",
 		mcp.WithDescription("Execute go mod tidy in the workspace"),
+		mcp.WithTitleAnnotation("Run Go Mod Tidy"),
+		mcp.WithDestructiveHintAnnotation(true),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -86,6 +90,8 @@ func (t *LSPTools) registerGoModTidy(s *server.MCPServer) {
 func (t *LSPTools) registerGovulncheck(s *server.MCPServer) {
 	tool := mcp.NewTool("run_govulncheck",
 		mcp.WithDescription("Execute govulncheck ./... in the workspace"),
+		mcp.WithTitleAnnotation("Run Govulncheck"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -128,6 +134,8 @@ func determineGovulncheckCommand() (string, []string, bool) {
 func (t *LSPTools) registerModuleGraph(s *server.MCPServer) {
 	tool := mcp.NewTool("module_graph",
 		mcp.WithDescription("Return the Go module dependency graph"),
+		mcp.WithTitleAnnotation("Module Graph"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	)
 
 	s.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 14 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

- Added `readOnlyHint: true` to 13 read-only tools:
  - **Navigation:** `go_to_definition`, `find_references`
  - **Diagnostics:** `check_diagnostics`
  - **Insight:** `get_hover_info`, `get_completion`
  - **Refactor:** `format_document`, `rename_symbol`, `list_code_actions`
  - **Testing:** `analyze_coverage`, `run_go_test`
  - **Workspace:** `search_workspace_symbols`, `run_govulncheck`, `module_graph`

- Added `destructiveHint: true` to 1 tool that modifies files:
  - `run_go_mod_tidy` (modifies go.mod/go.sum)

- Added human-readable `title` annotations to all 14 tools

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation

## Testing

- [x] Project builds successfully (`go build ./...`)
- [x] All 14 tools annotated with appropriate hints
- [x] Annotation values match actual tool behavior

## Before/After

**Before:**
```go
tool := mcp.NewTool("go_to_definition",
    mcp.WithDescription("Navigate to the definition of a symbol"),
    // No annotations
)
```

**After:**
```go
tool := mcp.NewTool("go_to_definition",
    mcp.WithDescription("Navigate to the definition of a symbol"),
    mcp.WithTitleAnnotation("Go To Definition"),
    mcp.WithReadOnlyHintAnnotation(true),
)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)