### PR TITLE
fix: unify URI handling, fix document lifecycle, remove dead code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - unconvert
+    - gofmt
+    - goimports
+    - gocritic
+    - revive
+
+linters-settings:
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: error-return
+      - name: error-naming
+      - name: exported
+        disabled: true
+      - name: var-naming
+      - name: package-comments
+        disabled: true
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/pkg/fs/watcher.go
+++ b/pkg/fs/watcher.go
@@ -142,7 +142,7 @@ func (w *Watcher) eventLoop(ctx context.Context, fsWatcher *fsnotify.Watcher) {
 				continue
 			}
 
-			uri := pathToURI(event.Name)
+			uri := protocol.PathToURI(event.Name)
 
 			mu.Lock()
 			// Preserve Created over Changed: if a file was just created, do not
@@ -193,17 +193,4 @@ func toFileChangeType(op fsnotify.Op) protocol.FileChangeType {
 	default:
 		return 0
 	}
-}
-
-// pathToURI converts an absolute filesystem path to an LSP file:// URI.
-func pathToURI(path string) string {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		abs = path
-	}
-	abs = filepath.ToSlash(abs)
-	if !strings.HasPrefix(abs, "/") {
-		abs = "/" + abs
-	}
-	return "file://" + abs
 }

--- a/pkg/lsp/client/gopls.go
+++ b/pkg/lsp/client/gopls.go
@@ -86,8 +86,6 @@ type GoplsClient struct {
 
 	diagnosticsMu       sync.RWMutex
 	diagnosticsCache    map[string][]protocol.Diagnostic
-	diagnosticsHandlers map[int64]DiagnosticsHandler
-	handlerCounter      atomic.Int64
 
 	openedDocs sync.Map
 
@@ -170,8 +168,7 @@ func NewGoplsClient(opts ...Option) (*GoplsClient, error) {
 		callTimeout:         cfg.callTimeout,
 		workspaceDir:        workspaceDir,
 		workspaceURI:        workspaceURI,
-		diagnosticsCache:    make(map[string][]protocol.Diagnostic),
-		diagnosticsHandlers: make(map[int64]DiagnosticsHandler),
+		diagnosticsCache:   make(map[string][]protocol.Diagnostic),
 		pending:             make(map[int64]chan rpcResponse),
 		diagnosticsWaiters:  make(map[string][]chan struct{}),
 	}
@@ -779,6 +776,16 @@ func (c *GoplsClient) GetCompletion(ctx context.Context, uri string, line, chara
 }
 
 func (c *GoplsClient) DocumentFormatting(ctx context.Context, uri string) ([]protocol.TextEdit, error) {
+	opened, err := c.ensureDocumentOpen(uri, "go", "")
+	if err != nil {
+		return nil, err
+	}
+	if opened {
+		defer func() {
+			_ = c.DidClose(ctx, uri)
+		}()
+	}
+
 	params := protocol.DocumentFormattingParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 		Options: protocol.FormattingOptions{
@@ -800,6 +807,16 @@ func (c *GoplsClient) DocumentFormatting(ctx context.Context, uri string) ([]pro
 }
 
 func (c *GoplsClient) Rename(ctx context.Context, uri string, line, character int, newName string) (*protocol.WorkspaceEdit, error) {
+	opened, err := c.ensureDocumentOpen(uri, "go", "")
+	if err != nil {
+		return nil, err
+	}
+	if opened {
+		defer func() {
+			_ = c.DidClose(ctx, uri)
+		}()
+	}
+
 	params := protocol.RenameParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
@@ -824,11 +841,32 @@ func (c *GoplsClient) Rename(ctx context.Context, uri string, line, character in
 }
 
 func (c *GoplsClient) CodeActions(ctx context.Context, uri string, rng protocol.Range) ([]protocol.CodeAction, error) {
+	opened, err := c.ensureDocumentOpen(uri, "go", "")
+	if err != nil {
+		return nil, err
+	}
+	if opened {
+		defer func() {
+			_ = c.DidClose(ctx, uri)
+		}()
+	}
+
+	// Use cached diagnostics (best-effort) so gopls can suggest quick-fixes.
+	var diagnostics []protocol.Diagnostic
+	if c.diagnosticsCache != nil {
+		c.diagnosticsMu.RLock()
+		diagnostics = c.diagnosticsCache[uri]
+		c.diagnosticsMu.RUnlock()
+	}
+	if diagnostics == nil {
+		diagnostics = []protocol.Diagnostic{}
+	}
+
 	params := protocol.CodeActionParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
 		Range:        rng,
 		Context: protocol.CodeActionContext{
-			Diagnostics: []protocol.Diagnostic{},
+			Diagnostics: diagnostics,
 		},
 	}
 
@@ -868,24 +906,6 @@ func (c *GoplsClient) NotifyDidChangeWatchedFiles(_ context.Context, changes []p
 	return c.notify("workspace/didChangeWatchedFiles", params)
 }
 
-// OnDiagnostics registers a handler for publishDiagnostics notifications.
-func (c *GoplsClient) OnDiagnostics(handler DiagnosticsHandler) func() {
-	if handler == nil {
-		return func() {}
-	}
-
-	id := c.handlerCounter.Add(1)
-	c.diagnosticsMu.Lock()
-	c.diagnosticsHandlers[id] = handler
-	c.diagnosticsMu.Unlock()
-
-	return func() {
-		c.diagnosticsMu.Lock()
-		delete(c.diagnosticsHandlers, id)
-		c.diagnosticsMu.Unlock()
-	}
-}
-
 func (c *GoplsClient) handleNotification(msg *protocol.JSONRPCMessage) {
 	switch msg.Method {
 	case "textDocument/publishDiagnostics":
@@ -903,11 +923,6 @@ func (c *GoplsClient) handleNotification(msg *protocol.JSONRPCMessage) {
 func (c *GoplsClient) updateDiagnostics(params protocol.PublishDiagnosticsParams) {
 	c.diagnosticsMu.Lock()
 	c.diagnosticsCache[params.URI] = params.Diagnostics
-
-	handlers := make([]DiagnosticsHandler, 0, len(c.diagnosticsHandlers))
-	for _, h := range c.diagnosticsHandlers {
-		handlers = append(handlers, h)
-	}
 	waiters := c.diagnosticsWaiters[params.URI]
 	if len(waiters) > 0 {
 		delete(c.diagnosticsWaiters, params.URI)
@@ -919,10 +934,6 @@ func (c *GoplsClient) updateDiagnostics(params protocol.PublishDiagnosticsParams
 		case waiter <- struct{}{}:
 		default:
 		}
-	}
-
-	for _, handler := range handlers {
-		handler(params)
 	}
 }
 
@@ -1067,7 +1078,7 @@ func resolveWorkspace(dir string) (string, string, error) {
 		return "", "", fmt.Errorf("workspace directory invalid: %w", statErr)
 	}
 
-	return dir, pathToURI(dir), nil
+	return dir, protocol.PathToURI(dir), nil
 }
 
 func buildGoplsEnv(env []string) []string {
@@ -1131,19 +1142,6 @@ func findGoRoot(start string) string {
 		}
 		current = next
 	}
-}
-
-func pathToURI(path string) string {
-	path = filepath.Clean(path)
-	if runtime.GOOS == "windows" {
-		path = strings.ReplaceAll(path, "\\", "/")
-		if len(path) >= 2 && path[1] == ':' {
-			drive := strings.ToLower(string(path[0]))
-			path = "/" + drive + ":" + path[2:]
-		}
-	}
-	u := url.URL{Scheme: "file", Path: path}
-	return u.String()
 }
 
 func uriToPath(uri string) (string, error) {

--- a/pkg/lsp/client/gopls_diagnostics_test.go
+++ b/pkg/lsp/client/gopls_diagnostics_test.go
@@ -13,10 +13,9 @@ import (
 
 func newTestClient() *GoplsClient {
 	return &GoplsClient{
-		logger:              slog.New(slog.NewTextHandler(io.Discard, nil)),
-		diagnosticsCache:    make(map[string][]protocol.Diagnostic),
-		diagnosticsHandlers: make(map[int64]DiagnosticsHandler),
-		diagnosticsWaiters:  make(map[string][]chan struct{}),
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		diagnosticsCache:   make(map[string][]protocol.Diagnostic),
+		diagnosticsWaiters: make(map[string][]chan struct{}),
 	}
 }
 

--- a/pkg/lsp/client/interface.go
+++ b/pkg/lsp/client/interface.go
@@ -6,28 +6,25 @@ import (
 	"github.com/hloiseau/mcp-gopls/v2/pkg/lsp/protocol"
 )
 
-// DiagnosticsHandler is invoked whenever gopls publishes diagnostics.
-type DiagnosticsHandler func(protocol.PublishDiagnosticsParams)
-
-// LSPClient définit l'interface pour un client LSP.
+// LSPClient defines the interface for an LSP client.
 type LSPClient interface {
-	// Méthodes de base du protocole
+	// Core protocol methods
 	Initialize(ctx context.Context) error
 	Shutdown(ctx context.Context) error
 	Close(ctx context.Context) error
 
-	// Méthodes de navigation de code
+	// Code navigation methods
 	GoToDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error)
 	FindReferences(ctx context.Context, uri string, line, character int, includeDeclaration bool) ([]protocol.Location, error)
 
-	// Méthodes de diagnostic
+	// Diagnostic methods
 	GetDiagnostics(ctx context.Context, uri string) ([]protocol.Diagnostic, error)
 
-	// Méthodes de document
+	// Document methods
 	DidOpen(ctx context.Context, uri, languageID, text string) error
 	DidClose(ctx context.Context, uri string) error
 
-	// Support avancé
+	// Advanced support
 	GetHover(ctx context.Context, uri string, line, character int) (string, error)
 	GetCompletion(ctx context.Context, uri string, line, character int) ([]string, error)
 
@@ -35,9 +32,6 @@ type LSPClient interface {
 	Rename(ctx context.Context, uri string, line, character int, newName string) (*protocol.WorkspaceEdit, error)
 	CodeActions(ctx context.Context, uri string, rng protocol.Range) ([]protocol.CodeAction, error)
 	WorkspaceSymbols(ctx context.Context, query string) ([]protocol.SymbolInformation, error)
-
-	// Observability
-	OnDiagnostics(handler DiagnosticsHandler) func()
 
 	// NotifyDidChangeWatchedFiles signals gopls that files changed on disk,
 	// prompting it to invalidate its index for those paths.

--- a/pkg/lsp/protocol/uri.go
+++ b/pkg/lsp/protocol/uri.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// PathToURI converts a filesystem path to a file:// URI.
+// Relative paths are resolved against the current working directory.
+func PathToURI(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		abs = filepath.Clean(path)
+	}
+	return filePathToURI(abs)
+}
+
+// NormalizeFileURI returns uriOrPath unchanged if it already uses the file:// scheme,
+// otherwise converts it with PathToURI.
+func NormalizeFileURI(uriOrPath string) string {
+	if strings.HasPrefix(uriOrPath, "file://") {
+		return uriOrPath
+	}
+	return PathToURI(uriOrPath)
+}
+
+func filePathToURI(path string) string {
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		path = strings.ReplaceAll(path, "\\", "/")
+		if len(path) >= 2 && path[1] == ':' {
+			drive := strings.ToLower(string(path[0]))
+			path = "/" + drive + ":" + path[2:]
+		}
+	}
+	u := url.URL{Scheme: "file", Path: path}
+	return u.String()
+}

--- a/pkg/lsp/protocol/uri_test.go
+++ b/pkg/lsp/protocol/uri_test.go
@@ -1,0 +1,43 @@
+package protocol
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPathToURI(t *testing.T) {
+	t.Parallel()
+
+	abs := filepath.Join(t.TempDir(), "main.go")
+	uri := PathToURI(abs)
+
+	if !strings.HasPrefix(uri, "file://") {
+		t.Fatalf("expected file:// prefix, got %q", uri)
+	}
+	if !strings.HasSuffix(uri, "main.go") {
+		t.Fatalf("expected path to end with main.go, got %q", uri)
+	}
+
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(uri, ":/") {
+			t.Fatalf("expected Windows drive letter in URI, got %q", uri)
+		}
+	}
+}
+
+func TestNormalizeFileURI(t *testing.T) {
+	t.Parallel()
+
+	existing := "file:///tmp/example.go"
+	if got := NormalizeFileURI(existing); got != existing {
+		t.Fatalf("expected %q, got %q", existing, got)
+	}
+
+	abs := filepath.Join(t.TempDir(), "pkg", "foo.go")
+	got := NormalizeFileURI(abs)
+	if !strings.HasPrefix(got, "file://") {
+		t.Fatalf("expected file:// prefix, got %q", got)
+	}
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -56,7 +56,6 @@ func (s *stubLSPClient) CodeActions(ctx context.Context, uri string, rng protoco
 func (s *stubLSPClient) WorkspaceSymbols(ctx context.Context, query string) ([]protocol.SymbolInformation, error) {
 	return nil, nil
 }
-func (s *stubLSPClient) OnDiagnostics(handler client.DiagnosticsHandler) func() { return func() {} }
 func (s *stubLSPClient) NotifyDidChangeWatchedFiles(_ context.Context, _ []protocol.FileEvent) error {
 	return nil
 }

--- a/pkg/tools/diagnostics.go
+++ b/pkg/tools/diagnostics.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/hloiseau/mcp-gopls/v2/pkg/lsp/protocol"
 )
 
 func (t *LSPTools) registerDiagnosticsTools(s *server.MCPServer) {
@@ -35,9 +37,7 @@ func (t *LSPTools) registerCheckDiagnostics(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {

--- a/pkg/tools/insight.go
+++ b/pkg/tools/insight.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/hloiseau/mcp-gopls/v2/pkg/lsp/protocol"
 )
 
 func (t *LSPTools) registerInsightTools(s *server.MCPServer) {
@@ -45,9 +47,7 @@ func (t *LSPTools) registerHover(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {
@@ -104,9 +104,7 @@ func (t *LSPTools) registerCompletion(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {

--- a/pkg/tools/lsp_tools.go
+++ b/pkg/tools/lsp_tools.go
@@ -76,31 +76,6 @@ func (t *LSPTools) Register(s *server.MCPServer) {
 	t.registerWorkspaceTools(s)
 }
 
-func convertPathToURI(path string) string {
-	if !filepath.IsAbs(path) {
-		cwd, err := os.Getwd()
-		if err == nil {
-			path = filepath.Join(cwd, path)
-		}
-	}
-
-	path = filepath.Clean(path)
-
-	if !strings.HasPrefix(path, "file://") {
-		if filepath.Separator == '\\' {
-			path = strings.ReplaceAll(path, "\\", "/")
-			if len(path) >= 2 && path[1] == ':' {
-				drive := strings.ToLower(string(path[0]))
-				path = "/" + drive + ":" + path[2:]
-			}
-			path = "/" + strings.TrimPrefix(path, "/")
-		}
-		path = "file://" + path
-	}
-
-	return path
-}
-
 func getArguments(request mcp.CallToolRequest) (map[string]any, error) {
 	args := request.GetArguments()
 	if args == nil {

--- a/pkg/tools/navigation.go
+++ b/pkg/tools/navigation.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/hloiseau/mcp-gopls/v2/pkg/lsp/protocol"
 )
 
 func (t *LSPTools) registerNavigationTools(s *server.MCPServer) {
@@ -45,9 +47,7 @@ func (t *LSPTools) registerGoToDefinition(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {
@@ -102,9 +102,7 @@ func (t *LSPTools) registerFindReferences(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {

--- a/pkg/tools/refactor.go
+++ b/pkg/tools/refactor.go
@@ -3,10 +3,11 @@ package tools
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/hloiseau/mcp-gopls/v2/pkg/lsp/protocol"
 )
 
 func (t *LSPTools) registerRefactorTools(s *server.MCPServer) {
@@ -37,9 +38,7 @@ func (t *LSPTools) registerFormatDocument(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {
@@ -102,9 +101,7 @@ func (t *LSPTools) registerRenameSymbol(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {
@@ -160,9 +157,7 @@ func (t *LSPTools) registerCodeActionsTool(s *server.MCPServer) {
 			return nil, err
 		}
 
-		if !strings.HasPrefix(fileURI, "file://") {
-			fileURI = convertPathToURI(fileURI)
-		}
+		fileURI = protocol.NormalizeFileURI(fileURI)
 
 		lspClient := t.getClient()
 		if lspClient == nil {

--- a/pkg/tools/tools_end_to_end_test.go
+++ b/pkg/tools/tools_end_to_end_test.go
@@ -258,7 +258,6 @@ func (f *fakeLSPClient) CodeActions(ctx context.Context, uri string, rng protoco
 func (f *fakeLSPClient) WorkspaceSymbols(ctx context.Context, query string) ([]protocol.SymbolInformation, error) {
 	return f.symbols, nil
 }
-func (f *fakeLSPClient) OnDiagnostics(handler client.DiagnosticsHandler) func() { return func() {} }
 func (f *fakeLSPClient) NotifyDidChangeWatchedFiles(_ context.Context, _ []protocol.FileEvent) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

- Extract `PathToURI` and `NormalizeFileURI` into `pkg/lsp/protocol/uri.go`, replacing 3 duplicate implementations across tools, fs, and client packages
- Add `ensureDocumentOpen`/`DidClose` lifecycle to `DocumentFormatting`, `Rename`, and `CodeActions` (matching the pattern already used by hover, diagnostics, completion)
- Pass cached diagnostics to `CodeActions` so gopls can offer quick-fix suggestions
- Remove `OnDiagnostics`/`DiagnosticsHandler` (dead code — never wired in production)
- Translate French interface comments to English
- Add `.golangci.yml` with explicit linter configuration

## Verification

- `go build ./...` compiles cleanly
- `go test ./...` — 58 tests pass (2 new URI tests)

Made with [Cursor](https://cursor.com)