### PR TITLE
docs: fix documentation drift and align README with code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v2.1.0 – 2026-06-22
+
+### Added
+- **Filesystem watcher** – opt-in `--fs-watch` flag (or `MCP_GOPLS_FS_WATCH=true`) monitors `.go`, `go.mod`, and `go.sum` files and notifies gopls via `workspace/didChangeWatchedFiles`, preventing stale cache after refactors. (PR #13)
+- **DocumentChanges support** – `rename_symbol` now correctly handles gopls responses using the LSP 3.x `documentChanges` format. Previously, rename edits were silently lost. (PR #15)
+
+### Changed
+- **Go 1.26** – bumped `go` directive and Dockerfile to Go 1.26.
+- **Dependencies** – upgraded `mcp-go` v0.43.0 → v0.55.0, `fsnotify` v1.9.0 → v1.10.1, and all transitive dependencies.
+- **Logs to stderr** – log output moved from stdout to stderr to avoid interfering with JSON-RPC on stdout.
+- **Modernized code** – `go fix` applied `strings.CutPrefix` pattern (Go 1.20+).
+
+### Fixed
+- **Dockerfile** – updated base image to `golang:1.26-bookworm` to match `go.mod` requirement.
+- **Env var** – Dockerfile now uses `MCP_GOPLS_BIN` (matching the actual code) instead of the non-functional `MCP_GOPLS_GOPLS_PATH`.
+
+---
+
 ## v2.0.0 – 2025-11-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN go build -o /usr/local/bin/mcp-gopls ./cmd/mcp-gopls \
   && go install golang.org/x/tools/gopls@latest
 
-ENV MCP_GOPLS_GOPLS_PATH=/go/bin/gopls
+ENV MCP_GOPLS_BIN=/go/bin/gopls
 
 WORKDIR /workspace
 ENTRYPOINT ["mcp-gopls"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mcp-gopls – MCP server for Go (gopls)
 <!-- markdownlint-disable MD022 MD012 MD029 MD060 -->
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-![Go version](https://img.shields.io/badge/Go-1.25+-informational)
+![Go version](https://img.shields.io/badge/Go-1.26+-informational)
 [![CI](https://github.com/hloiseau/mcp-gopls/actions/workflows/ci.yml/badge.svg)](https://github.com/hloiseau/mcp-gopls/actions)
 [![Docker Image](https://img.shields.io/badge/ghcr.io-hloiseau/mcp--gopls-blue)](https://ghcr.io/hloiseau/mcp-gopls)
 
@@ -24,7 +24,7 @@ This MCP server helps AI assistants to:
 - Read workspace resources (overview + go.mod) and consume curated prompts
 
 > **Status:** Actively developed – used in real projects.  
-> Tested with Go 1.25.x and `gopls@latest`.  
+> Tested with Go 1.26.x and `gopls@latest`.  
 
 ## Architecture
 
@@ -39,7 +39,8 @@ The server communicates with [gopls](https://github.com/golang/tools/tree/master
 - **Extended LSP surface**: navigation, diagnostics, formatting, rename, code actions, hover, completion, workspace symbols
 - **Test & tooling helpers**: coverage analysis, `go test`, `go mod tidy`, `govulncheck`, `go mod graph`
 - **MCP extras**: resources (`resource://workspace/overview`, `resource://workspace/go.mod`) and prompts (`summarize_diagnostics`, `refactor_plan`)
-- **Progress streaming**: long-running commands emit `notifications/progress` events so clients can surface status updates
+- **Filesystem watching**: opt-in `--fs-watch` to keep gopls index fresh after external file changes
+- **Progress streaming**: long-running shell commands emit `notifications/progress` events so clients can surface status updates
 
 ### Feature comparison: `mcp-gopls` vs built-in `gopls` MCP
 
@@ -290,13 +291,11 @@ The inspector lets you call each tool/resource/prompt manually, which is handy f
 
 ## Progress Notifications
 
-Long-running tools emit structured `notifications/progress` events so IDEs can show rich status indicators:
+Long-running shell tools emit structured `notifications/progress` events so IDEs can show rich status indicators:
 
 - **Streaming progress** (`run_go_test`, `analyze_coverage`, `run_govulncheck`, `run_go_mod_tidy`) forwards incremental log lines and percentage updates. Cursor displays these as a live log.
-- **Start/complete events only** (`go_to_definition`, `find_references`, `rename_symbol`, etc.) fire a quick “started” event so the UI can show a spinner, followed by a completion payload with the final result.
-- Each progress token is now namespaced (e.g., `run_go_test/<rand>`) to avoid “unknown token” errors when multiple tools run concurrently.
-
-When integrating new tools, opt into streaming mode only if the underlying LSP/golang command produces meaningful interim output; otherwise stick to the lightweight start/complete flow to minimize noise.
+- Each progress token is namespaced (e.g., `run_go_test/<rand>`) to avoid "unknown token" errors when multiple tools run concurrently.
+- LSP-backed tools (`go_to_definition`, `find_references`, etc.) return results directly without progress events.
 
 ## Prompt Instructions
 
@@ -305,8 +304,8 @@ Both prompts are accessible from any MCP-aware client via the “Prompts” cata
 ### `summarize_diagnostics`
 
 - **When to use:** After `check_diagnostics` or `run_go_test` to turn raw diagnostics into actionable steps.
-- **Arguments:** None. The server automatically reads the last diagnostics payload cached by the tools layer.
-- **Typical workflow:** `check_diagnostics` → copy the returned array into the prompt input field (Cursor’s UI pastes it automatically when you select “Use last result”).
+- **Arguments:** None. Returns a system prompt instructing the AI to summarize diagnostics.
+- **Typical workflow:** Run `check_diagnostics` first, then use this prompt to guide the AI's analysis of the results.
 
 ### `refactor_plan`
 
@@ -340,8 +339,9 @@ The server supports various configuration options via command-line flags and env
 | `--workspace`         | `.`     | Absolute path to your Go project root          |
 | `--gopls-path`        | `gopls` | Path to the gopls binary                       |
 | `--log-level`         | `info`  | Log level (`debug`, `info`, `warn`, `error`)   |
-| `--rpc-timeout`       | `30s`   | RPC timeout for LSP calls                      |
-| `--shutdown-timeout`  | `5s`    | Timeout for graceful shutdown                  |
+| `--rpc-timeout`       | `45s`   | RPC timeout for LSP calls                      |
+| `--shutdown-timeout`  | `15s`   | Timeout for graceful shutdown                  |
+| `--fs-watch`          | `false` | Watch workspace for file changes and notify gopls |
 
 ### Environment Variables
 
@@ -350,10 +350,11 @@ All flags can be set via environment variables with the `MCP_GOPLS_` prefix:
 | Environment Variable       | Equivalent Flag       | Description                                    |
 |---------------------------|-----------------------|------------------------------------------------|
 | `MCP_GOPLS_WORKSPACE`     | `--workspace`         | Absolute path to your Go project root          |
-| `MCP_GOPLS_GOPLS_PATH`    | `--gopls-path`        | Path to the gopls binary                       |
+| `MCP_GOPLS_BIN`           | `--gopls-path`        | Path to the gopls binary                       |
 | `MCP_GOPLS_LOG_LEVEL`     | `--log-level`         | Log level (`debug`, `info`, `warn`, `error`)   |
-| `MCP_GOPLS_RPC_TIMEOUT`   | `--rpc-timeout`       | RPC timeout for LSP calls (e.g., `30s`, `1m`)  |
+| `MCP_GOPLS_RPC_TIMEOUT`   | `--rpc-timeout`       | RPC timeout for LSP calls (e.g., `45s`, `1m`)  |
 | `MCP_GOPLS_SHUTDOWN_TIMEOUT` | `--shutdown-timeout` | Timeout for graceful shutdown                |
+| `MCP_GOPLS_FS_WATCH`      | `--fs-watch`          | Enable filesystem watching (`true`/`false`)    |
 
 Command-line flags take precedence over environment variables.
 
@@ -409,7 +410,7 @@ All contributions should maintain test coverage and adhere to Go best practices.
 
 ## Prerequisites
 
-- Go 1.25+ (tested with `go1.25.4`)
+- Go 1.26+ (tested with `go1.26.x`)
 - `gopls` installed (`go install golang.org/x/tools/gopls@latest`)
 - Optional: `govulncheck` (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
 - The server forces `GOTOOLCHAIN=local` for its nested `gopls` process. If you need a different toolchain, set `GOTOOLCHAIN` in the environment before launching `mcp-gopls`.

--- a/pkg/lsp/protocol/types.go
+++ b/pkg/lsp/protocol/types.go
@@ -1,46 +1,46 @@
 package protocol
 
-// Position représente une position dans un document texte
+// Position represents a position in a text document.
 type Position struct {
 	Line      int `json:"line"`
 	Character int `json:"character"`
 }
 
-// Range représente une plage dans un document texte
+// Range represents a span in a text document.
 type Range struct {
 	Start Position `json:"start"`
 	End   Position `json:"end"`
 }
 
-// Location représente un emplacement dans un document texte
+// Location represents a location in a text document.
 type Location struct {
 	URI   string `json:"uri"`
 	Range Range  `json:"range"`
 }
 
-// TextDocumentIdentifier identifie un document texte
+// TextDocumentIdentifier identifies a text document.
 type TextDocumentIdentifier struct {
 	URI string `json:"uri"`
 }
 
-// TextDocumentPositionParams paramètres pour les requêtes basées sur la position
+// TextDocumentPositionParams holds parameters for position-based requests.
 type TextDocumentPositionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Position     Position               `json:"position"`
 }
 
-// ReferenceContext contexte pour une requête de références
+// ReferenceContext provides context for a references request.
 type ReferenceContext struct {
 	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
-// ReferenceParams paramètres pour les requêtes de références
+// ReferenceParams holds parameters for references requests.
 type ReferenceParams struct {
 	TextDocumentPositionParams
 	Context ReferenceContext `json:"context"`
 }
 
-// Diagnostic représente un diagnostic comme un problème de code
+// Diagnostic represents a code diagnostic (error, warning, etc.).
 type Diagnostic struct {
 	Range    Range  `json:"range"`
 	Severity int    `json:"severity,omitempty"` // 1=Error, 2=Warning, 3=Info, 4=Hint
@@ -49,14 +49,14 @@ type Diagnostic struct {
 	Message  string `json:"message"`
 }
 
-// PublishDiagnosticsParams représente la charge utile pour textDocument/publishDiagnostics.
+// PublishDiagnosticsParams holds the payload for textDocument/publishDiagnostics.
 type PublishDiagnosticsParams struct {
 	URI         string       `json:"uri"`
 	Version     *int         `json:"version,omitempty"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
 }
 
-// DiagnosticSeverity énumère les niveaux de sévérité des diagnostics
+// DiagnosticSeverity enumerates diagnostic severity levels.
 type DiagnosticSeverity int
 
 const (
@@ -66,62 +66,62 @@ const (
 	SeverityHint    DiagnosticSeverity = 4
 )
 
-// TextEdit représente une modification textuelle.
+// TextEdit represents a textual edit.
 type TextEdit struct {
 	Range   Range  `json:"range"`
 	NewText string `json:"newText"`
 }
 
-// FormattingOptions représente les options de formatage LSP.
+// FormattingOptions represents LSP formatting options.
 type FormattingOptions struct {
 	TabSize      int  `json:"tabSize"`
 	InsertSpaces bool `json:"insertSpaces"`
 }
 
-// DocumentFormattingParams paramètres pour textDocument/formatting.
+// DocumentFormattingParams holds parameters for textDocument/formatting.
 type DocumentFormattingParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Options      FormattingOptions      `json:"options"`
 }
 
-// TextDocumentEdit représente un ensemble de modifications pour un document spécifique.
+// TextDocumentEdit represents a set of edits for a specific document.
 type TextDocumentEdit struct {
 	TextDocument OptionalVersionedTextDocumentIdentifier `json:"textDocument"`
 	Edits        []TextEdit                              `json:"edits"`
 }
 
-// OptionalVersionedTextDocumentIdentifier identifie un document texte avec une version optionnelle.
+// OptionalVersionedTextDocumentIdentifier identifies a text document with an optional version.
 type OptionalVersionedTextDocumentIdentifier struct {
 	URI     string `json:"uri"`
 	Version *int   `json:"version"`
 }
 
-// WorkspaceEdit représente un ensemble de modifications.
+// WorkspaceEdit represents a set of workspace modifications.
 type WorkspaceEdit struct {
 	Changes         map[string][]TextEdit `json:"changes,omitempty"`
 	DocumentChanges []TextDocumentEdit    `json:"documentChanges,omitempty"`
 }
 
-// RenameParams paramètres pour textDocument/rename.
+// RenameParams holds parameters for textDocument/rename.
 type RenameParams struct {
 	TextDocumentPositionParams
 	NewName string `json:"newName"`
 }
 
-// CodeActionContext fournit le contexte d'une action de code.
+// CodeActionContext provides context for a code action request.
 type CodeActionContext struct {
 	Diagnostics []Diagnostic `json:"diagnostics,omitempty"`
 	Only        []string     `json:"only,omitempty"`
 }
 
-// CodeActionParams paramètres pour textDocument/codeAction.
+// CodeActionParams holds parameters for textDocument/codeAction.
 type CodeActionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Range        Range                  `json:"range"`
 	Context      CodeActionContext      `json:"context"`
 }
 
-// CodeAction représente une action de code disponible.
+// CodeAction represents an available code action.
 type CodeAction struct {
 	Title       string         `json:"title"`
 	Kind        string         `json:"kind,omitempty"`
@@ -129,12 +129,12 @@ type CodeAction struct {
 	Edit        *WorkspaceEdit `json:"edit,omitempty"`
 }
 
-// WorkspaceSymbolParams paramètres pour workspace/symbol.
+// WorkspaceSymbolParams holds parameters for workspace/symbol.
 type WorkspaceSymbolParams struct {
 	Query string `json:"query"`
 }
 
-// SymbolInformation décrit un symbole trouvé.
+// SymbolInformation describes a workspace symbol.
 type SymbolInformation struct {
 	Name     string   `json:"name"`
 	Kind     int      `json:"kind"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -205,7 +205,7 @@ func setupLogger(cfg Config) (*os.File, *slog.Logger, error) {
 func setupServer(logger *slog.Logger) *mcpsrv.MCPServer {
 	srv := mcpsrv.NewMCPServer(
 		"MCP LSP Go",
-		"2.0.0",
+		"2.1.0",
 		mcpsrv.WithLogging(),
 		mcpsrv.WithToolCapabilities(true),
 		mcpsrv.WithResourceCapabilities(true, true),


### PR DESCRIPTION
## Summary

- Update Go version references from 1.25 to 1.26 (badge, prerequisites, status)
- Fix default timeout values in config tables (RPC: 45s, shutdown: 15s)
- Add `--fs-watch` / `MCP_GOPLS_FS_WATCH` to both config tables
- Fix env var: `MCP_GOPLS_BIN` (what the code uses) instead of `MCP_GOPLS_GOPLS_PATH`
- Fix Dockerfile to use `MCP_GOPLS_BIN`
- Correct `summarize_diagnostics` description (returns static prompt, not cached diagnostics)
- Fix progress notifications section (only shell tools emit progress events)
- Translate all French comments to English in `pkg/lsp/protocol/types.go`
- Bump MCP server version string to `"2.1.0"`
- Add v2.1.0 entries to CHANGELOG

## Verification

- `go build ./...` compiles cleanly
- `go test ./...` — 56 tests pass

Made with [Cursor](https://cursor.com)