### PR TITLE
feat: add type definition, implementation, and document symbols tools

### DIFF
--- a/pkg/lsp/client/gopls.go
+++ b/pkg/lsp/client/gopls.go
@@ -525,6 +525,50 @@ func (c *GoplsClient) GoToDefinition(ctx context.Context, uri string, line, char
 	return locations, nil
 }
 
+// GoToTypeDefinition implements LSPClient.
+func (c *GoplsClient) GoToTypeDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	params := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position: protocol.Position{
+			Line:      line,
+			Character: character,
+		},
+	}
+
+	resp, err := c.invoke(ctx, "textDocument/typeDefinition", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var locations []protocol.Location
+	if err := resp.ParseResult(&locations); err != nil {
+		return nil, fmt.Errorf("decode type definition: %w", err)
+	}
+	return locations, nil
+}
+
+// GoToImplementation implements LSPClient.
+func (c *GoplsClient) GoToImplementation(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	params := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position: protocol.Position{
+			Line:      line,
+			Character: character,
+		},
+	}
+
+	resp, err := c.invoke(ctx, "textDocument/implementation", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var locations []protocol.Location
+	if err := resp.ParseResult(&locations); err != nil {
+		return nil, fmt.Errorf("decode implementation: %w", err)
+	}
+	return locations, nil
+}
+
 // FindReferences implements LSPClient.
 func (c *GoplsClient) FindReferences(ctx context.Context, uri string, line, character int, includeDeclaration bool) ([]protocol.Location, error) {
 	params := protocol.ReferenceParams{
@@ -550,6 +594,36 @@ func (c *GoplsClient) FindReferences(ctx context.Context, uri string, line, char
 		return nil, fmt.Errorf("decode references: %w", err)
 	}
 	return locations, nil
+}
+
+// DocumentSymbols implements LSPClient.
+func (c *GoplsClient) DocumentSymbols(ctx context.Context, uri string) ([]protocol.DocumentSymbol, error) {
+	opened, err := c.ensureDocumentOpen(uri, "go", "")
+	if err != nil {
+		return nil, err
+	}
+	if opened {
+		defer func() {
+			_ = c.DidClose(ctx, uri)
+		}()
+	}
+
+	params := struct {
+		TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
+	}{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	}
+
+	resp, err := c.invoke(ctx, "textDocument/documentSymbol", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var symbols []protocol.DocumentSymbol
+	if err := resp.ParseResult(&symbols); err != nil {
+		return nil, fmt.Errorf("decode document symbols: %w", err)
+	}
+	return symbols, nil
 }
 
 func (c *GoplsClient) waitForDiagnostics(ctx context.Context, uri string) error {

--- a/pkg/lsp/client/gopls_helpers_test.go
+++ b/pkg/lsp/client/gopls_helpers_test.go
@@ -65,6 +65,74 @@ func TestNavigationAndRefactorHelpers(t *testing.T) {
 			},
 		},
 		{
+			name:         "type_definition",
+			expectMethod: "textDocument/typeDefinition",
+			call: func(c *GoplsClient) (any, error) {
+				return c.GoToTypeDefinition(context.Background(), uri, 1, 2)
+			},
+			response: []protocol.Location{{URI: uri}},
+			checkParams: func(t *testing.T, params any) {
+				t.Helper()
+				p, ok := params.(protocol.TextDocumentPositionParams)
+				if !ok || p.TextDocument.URI != uri || p.Position.Line != 1 {
+					t.Fatalf("unexpected params %#v", params)
+				}
+			},
+			verify: func(t *testing.T, result any) {
+				t.Helper()
+				locs := result.([]protocol.Location)
+				if len(locs) != 1 || locs[0].URI != uri {
+					t.Fatalf("unexpected locations %#v", locs)
+				}
+			},
+		},
+		{
+			name:         "implementation",
+			expectMethod: "textDocument/implementation",
+			call: func(c *GoplsClient) (any, error) {
+				return c.GoToImplementation(context.Background(), uri, 1, 2)
+			},
+			response: []protocol.Location{{URI: uri}},
+			checkParams: func(t *testing.T, params any) {
+				t.Helper()
+				p, ok := params.(protocol.TextDocumentPositionParams)
+				if !ok || p.TextDocument.URI != uri || p.Position.Line != 1 {
+					t.Fatalf("unexpected params %#v", params)
+				}
+			},
+			verify: func(t *testing.T, result any) {
+				t.Helper()
+				locs := result.([]protocol.Location)
+				if len(locs) != 1 || locs[0].URI != uri {
+					t.Fatalf("unexpected locations %#v", locs)
+				}
+			},
+		},
+		{
+			name:         "document_symbols",
+			expectMethod: "textDocument/documentSymbol",
+			call: func(c *GoplsClient) (any, error) {
+				return c.DocumentSymbols(context.Background(), uri)
+			},
+			response: []protocol.DocumentSymbol{{Name: "main", Kind: protocol.SymbolKindFunction}},
+			checkParams: func(t *testing.T, params any) {
+				t.Helper()
+				p, ok := params.(struct {
+					TextDocument protocol.TextDocumentIdentifier `json:"textDocument"`
+				})
+				if !ok || p.TextDocument.URI != uri {
+					t.Fatalf("unexpected document symbol params %#v", params)
+				}
+			},
+			verify: func(t *testing.T, result any) {
+				t.Helper()
+				syms := result.([]protocol.DocumentSymbol)
+				if len(syms) != 1 || syms[0].Name != "main" {
+					t.Fatalf("unexpected symbols %#v", syms)
+				}
+			},
+		},
+		{
 			name:         "hover",
 			expectMethod: "textDocument/hover",
 			call: func(c *GoplsClient) (any, error) {

--- a/pkg/lsp/client/interface.go
+++ b/pkg/lsp/client/interface.go
@@ -18,7 +18,10 @@ type LSPClient interface {
 
 	// Méthodes de navigation de code
 	GoToDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error)
+	GoToTypeDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error)
+	GoToImplementation(ctx context.Context, uri string, line, character int) ([]protocol.Location, error)
 	FindReferences(ctx context.Context, uri string, line, character int, includeDeclaration bool) ([]protocol.Location, error)
+	DocumentSymbols(ctx context.Context, uri string) ([]protocol.DocumentSymbol, error)
 
 	// Méthodes de diagnostic
 	GetDiagnostics(ctx context.Context, uri string) ([]protocol.Diagnostic, error)

--- a/pkg/lsp/protocol/types.go
+++ b/pkg/lsp/protocol/types.go
@@ -167,3 +167,39 @@ type DidChangeWatchedFilesParams struct {
 	// Changes is the list of file change events.
 	Changes []FileEvent `json:"changes"`
 }
+
+// SymbolKind represents the kind of a symbol (LSP spec 3.17).
+type SymbolKind int
+
+const (
+	SymbolKindFile         SymbolKind = 1
+	SymbolKindModule       SymbolKind = 2
+	SymbolKindNamespace    SymbolKind = 3
+	SymbolKindPackage      SymbolKind = 4
+	SymbolKindClass        SymbolKind = 5
+	SymbolKindMethod       SymbolKind = 6
+	SymbolKindProperty     SymbolKind = 7
+	SymbolKindField        SymbolKind = 8
+	SymbolKindConstructor  SymbolKind = 9
+	SymbolKindEnum         SymbolKind = 10
+	SymbolKindInterface    SymbolKind = 11
+	SymbolKindFunction     SymbolKind = 12
+	SymbolKindVariable     SymbolKind = 13
+	SymbolKindConstant     SymbolKind = 14
+	SymbolKindString       SymbolKind = 15
+	SymbolKindNumber       SymbolKind = 16
+	SymbolKindBoolean      SymbolKind = 17
+	SymbolKindArray        SymbolKind = 18
+	SymbolKindObject       SymbolKind = 19
+	SymbolKindStruct       SymbolKind = 23
+)
+
+// DocumentSymbol represents a symbol in a document with optional children.
+type DocumentSymbol struct {
+	Name           string           `json:"name"`
+	Detail         string           `json:"detail,omitempty"`
+	Kind           SymbolKind       `json:"kind"`
+	Range          Range            `json:"range"`
+	SelectionRange Range            `json:"selectionRange"`
+	Children       []DocumentSymbol `json:"children,omitempty"`
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -30,7 +30,16 @@ func (s *stubLSPClient) Close(ctx context.Context) error      { return s.closeEr
 func (s *stubLSPClient) GoToDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
 	return nil, nil
 }
+func (s *stubLSPClient) GoToTypeDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	return nil, nil
+}
+func (s *stubLSPClient) GoToImplementation(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	return nil, nil
+}
 func (s *stubLSPClient) FindReferences(ctx context.Context, uri string, line, character int, includeDeclaration bool) ([]protocol.Location, error) {
+	return nil, nil
+}
+func (s *stubLSPClient) DocumentSymbols(ctx context.Context, uri string) ([]protocol.DocumentSymbol, error) {
 	return nil, nil
 }
 func (s *stubLSPClient) GetDiagnostics(ctx context.Context, uri string) ([]protocol.Diagnostic, error) {

--- a/pkg/tools/navigation.go
+++ b/pkg/tools/navigation.go
@@ -12,6 +12,9 @@ import (
 func (t *LSPTools) registerNavigationTools(s *server.MCPServer) {
 	t.registerGoToDefinition(s)
 	t.registerFindReferences(s)
+	t.registerGoToTypeDefinition(s)
+	t.registerGoToImplementation(s)
+	t.registerDocumentSymbols(s)
 }
 
 func (t *LSPTools) registerGoToDefinition(s *server.MCPServer) {

--- a/pkg/tools/navigation_extended.go
+++ b/pkg/tools/navigation_extended.go
@@ -1,0 +1,172 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func (t *LSPTools) registerGoToTypeDefinition(s *server.MCPServer) {
+	typeDefinitionTool := mcp.NewTool("go_to_type_definition",
+		mcp.WithDescription("Navigate to the type definition of a symbol"),
+		mcp.WithTitleAnnotation("Go To Type Definition"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("file_uri",
+			mcp.Required(),
+			mcp.Description("URI of the file"),
+		),
+		mcp.WithObject("position",
+			mcp.Required(),
+			mcp.Description("Position of the symbol"),
+		),
+	)
+
+	s.AddTool(typeDefinitionTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, err := getArguments(request)
+		if err != nil {
+			return nil, err
+		}
+
+		fileURI, err := getStringArg(args, "file_uri")
+		if err != nil {
+			return nil, err
+		}
+
+		line, character, err := parsePosition(args)
+		if err != nil {
+			return nil, err
+		}
+
+		if !strings.HasPrefix(fileURI, "file://") {
+			fileURI = convertPathToURI(fileURI)
+		}
+
+		lspClient := t.getClient()
+		if lspClient == nil {
+			return nil, fmt.Errorf("LSP client not available")
+		}
+
+		locations, err := lspClient.GoToTypeDefinition(ctx, fileURI, line, character)
+		if err != nil {
+			return nil, t.handleLSPError(err)
+		}
+
+		payload := map[string]any{
+			"file_uri":  fileURI,
+			"positions": locations,
+		}
+		result, err := mcp.NewToolResultJSON(payload)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	})
+}
+
+func (t *LSPTools) registerGoToImplementation(s *server.MCPServer) {
+	implementationTool := mcp.NewTool("go_to_implementation",
+		mcp.WithDescription("Navigate to the implementation of a symbol"),
+		mcp.WithTitleAnnotation("Go To Implementation"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("file_uri",
+			mcp.Required(),
+			mcp.Description("URI of the file"),
+		),
+		mcp.WithObject("position",
+			mcp.Required(),
+			mcp.Description("Position of the symbol"),
+		),
+	)
+
+	s.AddTool(implementationTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, err := getArguments(request)
+		if err != nil {
+			return nil, err
+		}
+
+		fileURI, err := getStringArg(args, "file_uri")
+		if err != nil {
+			return nil, err
+		}
+
+		line, character, err := parsePosition(args)
+		if err != nil {
+			return nil, err
+		}
+
+		if !strings.HasPrefix(fileURI, "file://") {
+			fileURI = convertPathToURI(fileURI)
+		}
+
+		lspClient := t.getClient()
+		if lspClient == nil {
+			return nil, fmt.Errorf("LSP client not available")
+		}
+
+		locations, err := lspClient.GoToImplementation(ctx, fileURI, line, character)
+		if err != nil {
+			return nil, t.handleLSPError(err)
+		}
+
+		payload := map[string]any{
+			"file_uri":  fileURI,
+			"positions": locations,
+		}
+		result, err := mcp.NewToolResultJSON(payload)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	})
+}
+
+func (t *LSPTools) registerDocumentSymbols(s *server.MCPServer) {
+	documentSymbolsTool := mcp.NewTool("document_symbols",
+		mcp.WithDescription("Get the hierarchical symbol outline of a document"),
+		mcp.WithTitleAnnotation("Document Symbols"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithString("file_uri",
+			mcp.Required(),
+			mcp.Description("URI of the file"),
+		),
+	)
+
+	s.AddTool(documentSymbolsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, err := getArguments(request)
+		if err != nil {
+			return nil, err
+		}
+
+		fileURI, err := getStringArg(args, "file_uri")
+		if err != nil {
+			return nil, err
+		}
+
+		if !strings.HasPrefix(fileURI, "file://") {
+			fileURI = convertPathToURI(fileURI)
+		}
+
+		lspClient := t.getClient()
+		if lspClient == nil {
+			return nil, fmt.Errorf("LSP client not available")
+		}
+
+		symbols, err := lspClient.DocumentSymbols(ctx, fileURI)
+		if err != nil {
+			return nil, t.handleLSPError(err)
+		}
+
+		payload := map[string]any{
+			"file_uri": fileURI,
+			"symbols":  symbols,
+		}
+		result, err := mcp.NewToolResultJSON(payload)
+		if err != nil {
+			return nil, err
+		}
+		return result, nil
+	})
+}

--- a/pkg/tools/tools_end_to_end_test.go
+++ b/pkg/tools/tools_end_to_end_test.go
@@ -232,8 +232,17 @@ func (f *fakeLSPClient) Close(ctx context.Context) error      { return nil }
 func (f *fakeLSPClient) GoToDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
 	return f.definitions, nil
 }
+func (f *fakeLSPClient) GoToTypeDefinition(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	return nil, nil
+}
+func (f *fakeLSPClient) GoToImplementation(ctx context.Context, uri string, line, character int) ([]protocol.Location, error) {
+	return nil, nil
+}
 func (f *fakeLSPClient) FindReferences(ctx context.Context, uri string, line, character int, includeDeclaration bool) ([]protocol.Location, error) {
 	return f.references, nil
+}
+func (f *fakeLSPClient) DocumentSymbols(ctx context.Context, uri string) ([]protocol.DocumentSymbol, error) {
+	return nil, nil
 }
 func (f *fakeLSPClient) GetDiagnostics(ctx context.Context, uri string) ([]protocol.Diagnostic, error) {
 	return f.diagnostics, nil


### PR DESCRIPTION
## Summary

Adds three new LSP navigation/context MCP tools:

- **`go_to_type_definition`** — navigates to the type definition of a symbol at the given position (wraps `textDocument/typeDefinition`)
- **`go_to_implementation`** — navigates to the implementation(s) of an interface or abstract symbol (wraps `textDocument/implementation`)
- **`document_symbols`** — returns the hierarchical symbol outline of a file (functions, types, methods, etc.) via `textDocument/documentSymbol`

Also adds `DocumentSymbol` and `SymbolKind` LSP protocol types, client interface methods, gopls client implementations, and unit test coverage.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout 60s`
- [ ] Manual: call `go_to_type_definition` on a variable to jump to its type
- [ ] Manual: call `go_to_implementation` on an interface method
- [ ] Manual: call `document_symbols` on a Go file and verify hierarchical outline


Made with [Cursor](https://cursor.com)