### PR TITLE
feat: richer completion and hover payloads

### DIFF
--- a/pkg/lsp/client/gopls.go
+++ b/pkg/lsp/client/gopls.go
@@ -736,7 +736,7 @@ func (c *GoplsClient) GetHover(ctx context.Context, uri string, line, character 
 }
 
 // GetCompletion implements LSPClient.
-func (c *GoplsClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]string, error) {
+func (c *GoplsClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]protocol.CompletionItem, error) {
 	opened, err := c.ensureDocumentOpen(uri, "go", "")
 	if err != nil {
 		return nil, err
@@ -759,23 +759,71 @@ func (c *GoplsClient) GetCompletion(ctx context.Context, uri string, line, chara
 		return nil, err
 	}
 
+	if resp.Result == nil || string(resp.Result) == "null" {
+		return nil, nil
+	}
+
+	var list protocol.CompletionList
+	if err := resp.ParseResult(&list); err == nil && list.Items != nil {
+		return list.Items, nil
+	}
+
+	var items []protocol.CompletionItem
+	if err := resp.ParseResult(&items); err == nil {
+		return items, nil
+	}
+
 	var payload map[string]any
 	if err := resp.ParseResult(&payload); err != nil {
 		return nil, fmt.Errorf("decode completion: %w", err)
 	}
 
-	var completions []string
-	if items, ok := payload["items"].([]any); ok {
-		for _, item := range items {
-			if dict, ok := item.(map[string]any); ok {
-				if label, ok := dict["label"].(string); ok {
-					completions = append(completions, label)
-				}
-			}
-		}
+	return parseCompletionItems(payload), nil
+}
+
+func parseCompletionItems(payload map[string]any) []protocol.CompletionItem {
+	rawItems, ok := payload["items"].([]any)
+	if !ok {
+		return nil
 	}
 
-	return completions, nil
+	items := make([]protocol.CompletionItem, 0, len(rawItems))
+	for _, raw := range rawItems {
+		dict, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		item := protocol.CompletionItem{}
+		if label, ok := dict["label"].(string); ok {
+			item.Label = label
+		}
+		if detail, ok := dict["detail"].(string); ok {
+			item.Detail = detail
+		}
+		if insertText, ok := dict["insertText"].(string); ok {
+			item.InsertText = insertText
+		}
+		if kind, ok := dict["kind"].(float64); ok {
+			item.Kind = int(kind)
+		}
+		if doc, ok := dict["documentation"]; ok {
+			item.Documentation = extractMarkupContent(doc)
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func extractMarkupContent(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case map[string]any:
+		if text, ok := v["value"].(string); ok {
+			return text
+		}
+	}
+	return ""
 }
 
 func (c *GoplsClient) DocumentFormatting(ctx context.Context, uri string) ([]protocol.TextEdit, error) {

--- a/pkg/lsp/client/gopls_helpers_test.go
+++ b/pkg/lsp/client/gopls_helpers_test.go
@@ -92,7 +92,13 @@ func TestNavigationAndRefactorHelpers(t *testing.T) {
 			},
 			response: map[string]any{
 				"items": []any{
-					map[string]any{"label": "Foo"},
+					map[string]any{
+						"label":         "Foo",
+						"detail":        "func()",
+						"documentation": map[string]any{"value": "Foo docs"},
+						"kind":          3.0,
+						"insertText":    "Foo()",
+					},
 				},
 			},
 			checkParams: func(t *testing.T, params any) {
@@ -103,9 +109,13 @@ func TestNavigationAndRefactorHelpers(t *testing.T) {
 			},
 			verify: func(t *testing.T, result any) {
 				t.Helper()
-				items := result.([]string)
-				if len(items) != 1 || items[0] != "Foo" {
+				items := result.([]protocol.CompletionItem)
+				if len(items) != 1 {
 					t.Fatalf("unexpected completion %#v", items)
+				}
+				item := items[0]
+				if item.Label != "Foo" || item.Detail != "func()" || item.Documentation != "Foo docs" || item.Kind != 3 || item.InsertText != "Foo()" {
+					t.Fatalf("unexpected completion item %#v", item)
 				}
 			},
 		},

--- a/pkg/lsp/client/interface.go
+++ b/pkg/lsp/client/interface.go
@@ -29,7 +29,7 @@ type LSPClient interface {
 
 	// Support avancé
 	GetHover(ctx context.Context, uri string, line, character int) (string, error)
-	GetCompletion(ctx context.Context, uri string, line, character int) ([]string, error)
+	GetCompletion(ctx context.Context, uri string, line, character int) ([]protocol.CompletionItem, error)
 
 	DocumentFormatting(ctx context.Context, uri string) ([]protocol.TextEdit, error)
 	Rename(ctx context.Context, uri string, line, character int, newName string) (*protocol.WorkspaceEdit, error)

--- a/pkg/lsp/protocol/types.go
+++ b/pkg/lsp/protocol/types.go
@@ -167,3 +167,17 @@ type DidChangeWatchedFilesParams struct {
 	// Changes is the list of file change events.
 	Changes []FileEvent `json:"changes"`
 }
+
+// CompletionItem represents a single completion suggestion from textDocument/completion.
+type CompletionItem struct {
+	Label         string `json:"label"`
+	Detail        string `json:"detail,omitempty"`
+	Documentation string `json:"documentation,omitempty"`
+	Kind          int    `json:"kind,omitempty"`
+	InsertText    string `json:"insertText,omitempty"`
+}
+
+// CompletionList is the structured response for textDocument/completion.
+type CompletionList struct {
+	Items []CompletionItem `json:"items"`
+}

--- a/pkg/server/prompts.go
+++ b/pkg/server/prompts.go
@@ -16,6 +16,12 @@ type promptDefinition struct {
 func (s *Service) promptDefinitions() []promptDefinition {
 	diagPrompt := mcp.NewPrompt("summarize_diagnostics",
 		mcp.WithPromptDescription("Summarize Go diagnostics returned by the check_diagnostics tool."),
+		mcp.WithArgument("file_uri",
+			mcp.ArgumentDescription("Optional file URI the diagnostics refer to"),
+		),
+		mcp.WithArgument("diagnostics",
+			mcp.ArgumentDescription("JSON diagnostics payload from check_diagnostics (paste the tool output here)"),
+		),
 	)
 
 	refactorPrompt := mcp.NewPrompt("refactor_plan",
@@ -30,11 +36,28 @@ func (s *Service) promptDefinitions() []promptDefinition {
 		{
 			prompt: diagPrompt,
 			handler: func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+				fileURI := request.Params.Arguments["file_uri"]
+				diagnostics := request.Params.Arguments["diagnostics"]
+
+				messageText := fmt.Sprintf(`You are reviewing Go diagnostics for a Go workspace.
+Workspace root: %s`, s.config.WorkspaceDir)
+				if fileURI != "" {
+					messageText += fmt.Sprintf("\nFile URI: %s", fileURI)
+				}
+				if diagnostics != "" {
+					messageText += fmt.Sprintf("\n\nDiagnostics JSON:\n%s", diagnostics)
+				} else {
+					messageText += `
+
+No diagnostics were provided. Run the check_diagnostics tool first, then paste its JSON output into the diagnostics argument before invoking this prompt again.`
+				}
+				messageText += "\n\nProvide a concise summary highlighting root causes and suggested fixes."
+
 				message := mcp.PromptMessage{
 					Role: mcp.RoleUser,
 					Content: mcp.TextContent{
 						Type: "text",
-						Text: "You are reviewing Go diagnostics. Provide a concise summary highlighting root causes and suggested fixes.",
+						Text: messageText,
 					},
 				}
 				return &mcp.GetPromptResult{

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -41,7 +41,7 @@ func (s *stubLSPClient) DidClose(ctx context.Context, uri string) error         
 func (s *stubLSPClient) GetHover(ctx context.Context, uri string, line, character int) (string, error) {
 	return "", nil
 }
-func (s *stubLSPClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]string, error) {
+func (s *stubLSPClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]protocol.CompletionItem, error) {
 	return nil, nil
 }
 func (s *stubLSPClient) DocumentFormatting(ctx context.Context, uri string) ([]protocol.TextEdit, error) {
@@ -148,8 +148,25 @@ func TestPromptDefinitions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("diag handler error: %v", err)
 	}
-	if len(res.Messages) != 1 || !strings.Contains(res.Messages[0].Content.(mcp.TextContent).Text, "diagnostics") {
+	diagText := res.Messages[0].Content.(mcp.TextContent).Text
+	if len(res.Messages) != 1 || !strings.Contains(diagText, "check_diagnostics") {
 		t.Fatalf("unexpected diagnostics prompt message: %#v", res.Messages)
+	}
+
+	diagWithData, err := diag.handler(context.Background(), mcp.GetPromptRequest{
+		Params: mcp.GetPromptParams{
+			Arguments: map[string]string{
+				"file_uri":    "file:///tmp/main.go",
+				"diagnostics": `[{"message":"unused import"}]`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("diag handler with args error: %v", err)
+	}
+	diagWithDataText := diagWithData.Messages[0].Content.(mcp.TextContent).Text
+	if !strings.Contains(diagWithDataText, "file:///tmp/main.go") || !strings.Contains(diagWithDataText, "unused import") {
+		t.Fatalf("unexpected diagnostics prompt with args: %q", diagWithDataText)
 	}
 
 	refReq := mcp.GetPromptRequest{

--- a/pkg/tools/tools_end_to_end_test.go
+++ b/pkg/tools/tools_end_to_end_test.go
@@ -22,7 +22,7 @@ func TestToolsEndToEnd(t *testing.T) {
 		references:  []protocol.Location{{URI: "file://tmp/main.go"}},
 		diagnostics: []protocol.Diagnostic{{Message: "boom"}},
 		hover:       "hover info",
-		completions: []string{"CompleteMe"},
+		completions: []protocol.CompletionItem{{Label: "CompleteMe"}},
 		edits:       []protocol.TextEdit{{NewText: "fmt"}},
 		rename:      &protocol.WorkspaceEdit{Changes: map[string][]protocol.TextEdit{"file://tmp/main.go": {{NewText: "name"}}}},
 		actions:     []protocol.CodeAction{{Title: "Fix"}},
@@ -114,8 +114,13 @@ func TestToolsEndToEnd(t *testing.T) {
 		"file_uri": "file://tmp/main.go",
 		"position": map[string]any{"line": 0, "character": 0},
 	}, func(t *testing.T, content map[string]any) {
-		if len(content["completions"].([]any)) != 1 {
+		items := content["completions"].([]any)
+		if len(items) != 1 {
 			t.Fatalf("unexpected completions %#v", content)
+		}
+		first, ok := items[0].(map[string]any)
+		if !ok || first["label"] != "CompleteMe" {
+			t.Fatalf("unexpected completion item %#v", items[0])
 		}
 	})
 
@@ -219,7 +224,7 @@ type fakeLSPClient struct {
 	references  []protocol.Location
 	diagnostics []protocol.Diagnostic
 	hover       string
-	completions []string
+	completions []protocol.CompletionItem
 	edits       []protocol.TextEdit
 	rename      *protocol.WorkspaceEdit
 	actions     []protocol.CodeAction
@@ -243,7 +248,7 @@ func (f *fakeLSPClient) DidClose(ctx context.Context, uri string) error         
 func (f *fakeLSPClient) GetHover(ctx context.Context, uri string, line, character int) (string, error) {
 	return f.hover, nil
 }
-func (f *fakeLSPClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]string, error) {
+func (f *fakeLSPClient) GetCompletion(ctx context.Context, uri string, line, character int) ([]protocol.CompletionItem, error) {
 	return f.completions, nil
 }
 func (f *fakeLSPClient) DocumentFormatting(ctx context.Context, uri string) ([]protocol.TextEdit, error) {


### PR DESCRIPTION
## Summary
- Return structured `CompletionItem` payloads (label, detail, documentation, kind, insertText) from `get_completion` instead of label strings only
- Improve `summarize_diagnostics` prompt with optional `file_uri` and `diagnostics` arguments and clear instructions to paste `check_diagnostics` output

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout 60s`


Made with [Cursor](https://cursor.com)